### PR TITLE
Add Wayland clipboard support using wl-copy/wl-paste

### DIFF
--- a/src/setup_wizard_tui.jl
+++ b/src/setup_wizard_tui.jl
@@ -518,7 +518,8 @@ function update_api_key!(m::SetupWizardModel, evt::KeyEvent)
         try
             clipboard_cmd =
                 Sys.isapple() ? `pbcopy` :
-                Sys.islinux() ? `xclip -selection clipboard` : nothing
+                Sys.islinux() ? (haskey(ENV, "WAYLAND_DISPLAY") ? `wl-copy` : `xclip -selection clipboard`) :
+                nothing
             if clipboard_cmd !== nothing
                 open(clipboard_cmd, "w") do io
                     print(io, m.api_key)

--- a/src/tool_definitions.jl
+++ b/src/tool_definitions.jl
@@ -1398,7 +1398,7 @@ add_watch_expression_tool = @mcp_tool(
 
 copy_debug_value_tool = @mcp_tool(
     :copy_debug_value,
-    "Copy a debug variable value to clipboard. Read with pbpaste (macOS) or xclip (Linux). Requires VS Code with active debug session.",
+    "Copy a debug variable value to clipboard. Read with pbpaste (macOS), wl-paste (Wayland), or xclip (X11). Requires VS Code with active debug session.",
     Dict(
         "type" => "object",
         "properties" => Dict(
@@ -1432,7 +1432,11 @@ copy_debug_value_tool = @mcp_tool(
             clipboard_cmd = if Sys.isapple()
                 "pbpaste"
             elseif Sys.islinux()
-                "xclip -selection clipboard -o (or xsel --clipboard --output)"
+                if haskey(ENV, "WAYLAND_DISPLAY")
+                    "wl-paste"
+                else
+                    "xclip -selection clipboard -o (or xsel --clipboard --output)"
+                end
             elseif Sys.iswindows()
                 "powershell Get-Clipboard"
             else


### PR DESCRIPTION
Fix clipboard detection logic to check for Linux first, then determine if running on Wayland or X11:
- Wayland: uses wl-copy (write) / wl-paste (read)
- X11: uses xclip (write) / xclip -selection clipboard -o (read)
- macOS: uses pbcopy (write) / pbpaste (read)

Updated both setup_wizard_tui.jl and tool_definitions.jl