### PR TITLE
feat: manually restart gate from REPL and TUI

### DIFF
--- a/src/gate.jl
+++ b/src/gate.jl
@@ -2235,6 +2235,43 @@ function stop()
     printstyled("disconnected\n"; color = :yellow)
 end
 
+"""
+    restart()
+
+Restart the Julia session, preserving the Kaimon session ID so the TUI
+reconnects automatically.  Equivalent to what the agent's `manage_repl` tool
+does, but callable directly from your REPL.
+
+Uses `execvp` to replace the current process image — same PID, fresh Julia
+state.  Your startup.jl runs again and `Gate.serve()` reconnects with the
+same session key.
+"""
+function restart()
+    _RUNNING[] || error("Gate is not running")
+    _ALLOW_RESTART[] || error("Restart is disabled for this session (allow_restart=false)")
+    sid  = _SESSION_ID[]
+    name = basename(dirname(something(Base.active_project(), "julia")))
+    proj = dirname(something(Base.active_project(), "."))
+
+    # Tell the message-loop's finally block to skip cleanup — we handle it here.
+    _RESTARTING[] = true
+    _RUNNING[] = false
+
+    # Wait for the message-loop task to exit before tearing down sockets,
+    # same as stop() does.
+    task = _GATE_TASK[]
+    if task !== nothing && !istaskdone(task)
+        try
+            wait(task)
+        catch
+        end
+    end
+
+    _RESTARTING[] = false
+    _cleanup()
+    _exec_restart(name, sid, proj)
+end
+
 function _cleanup()
     # Stop Revise watcher
     watcher = _REVISE_WATCHER_TASK[]

--- a/src/tui/sessions.jl
+++ b/src/tui/sessions.jl
@@ -311,7 +311,7 @@ function _sync_sessions_table!(m::KaimonModel, connections::Vector{REPLConnectio
         ];
         selected = n > 0 ? clamp(m.selected_connection, 1, n) : 0,
         block = Block(
-            title = "REPL Sessions ($n) [x] shutdown [t] trace",
+            title = "REPL Sessions ($n) [r] restart [x] shutdown [t] trace",
             border_style = _pane_border(m, TAB_SESSIONS, 1),
             title_style = _pane_title(m, TAB_SESSIONS, 1),
         ),
@@ -443,6 +443,30 @@ function _shutdown_selected_session!(m::KaimonModel)
     m.selected_connection = clamp(m.selected_connection, 1, max(1, n))
 
     _push_log!(:info, "Shutdown session '$dname' ($sk)")
+end
+
+"""Restart the selected session from the Sessions tab."""
+function _restart_selected_session!(m::KaimonModel)
+    conns = _visible_connections(m)
+    (m.selected_connection < 1 || m.selected_connection > length(conns)) && return
+    conn = conns[m.selected_connection]
+    sk = short_key(conn)
+    dname = isempty(conn.display_name) ? conn.name : conn.display_name
+
+    # Close terminal widget if open for this session
+    if m.session_terminal_open && m.session_terminal_key == sk
+        _close_session_terminal!(m)
+    end
+
+    # Fire-and-forget: send restart command to gate.
+    # Unlike shutdown, we do NOT call stop_session! — execvp replaces the
+    # process image (same PID, same PTY) so the managed session stays valid
+    # and the gate will reconnect with the same session ID.
+    Threads.@spawn begin
+        send_restart!(conn)
+    end
+
+    _push_log!(:info, "Restart session '$dname' ($sk)")
 end
 
 """Save the current backtrace result to a file near the session's project."""

--- a/src/tui/update.jl
+++ b/src/tui/update.jl
@@ -684,6 +684,7 @@ function Tachikoma.update!(m::KaimonModel, evt::KeyEvent)
         end
 
         $TAB_SESSIONS => @match evt.char begin
+            'r' => _restart_selected_session!(m)
             'x' => _shutdown_selected_session!(m)
             't' => begin
                 conns = _visible_connections(m)

--- a/test/gate_async_tests.jl
+++ b/test/gate_async_tests.jl
@@ -410,3 +410,31 @@ end
 
     empty!(Kaimon._TCP_POLL_BACKOFF)
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Gate.restart() guard tests — unit tests, no ZMQ needed
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "Gate.restart guards" begin
+    orig_running = Kaimon.Gate._RUNNING[]
+    orig_restart = Kaimon.Gate._ALLOW_RESTART[]
+
+    @testset "errors when gate is not running" begin
+        Kaimon.Gate._RUNNING[] = false
+        @test_throws ErrorException("Gate is not running") Kaimon.Gate.restart()
+    end
+
+    @testset "errors when restart is disabled" begin
+        Kaimon.Gate._RUNNING[] = true
+        Kaimon.Gate._ALLOW_RESTART[] = false
+        @test_throws ErrorException("Restart is disabled for this session (allow_restart=false)") Kaimon.Gate.restart()
+    end
+
+    Kaimon.Gate._RUNNING[] = orig_running
+    Kaimon.Gate._ALLOW_RESTART[] = orig_restart
+end
+
+# NOTE: handle_message(:restart) is not unit-tested here because the handler
+# spawns an @async task that calls _exec_restart → execvp / exit(1) after a
+# 0.3 s delay, which would kill the test process. The :restart message path
+# is covered by the MCP manage_repl integration tests instead.


### PR DESCRIPTION
## Summary

- Add public `Gate.restart()` function for restarting the Julia session directly from the REPL, preserving the session ID so the TUI reconnects automatically
- Add `[r] restart` keybinding on the Sessions tab alongside the existing `[x] shutdown`
- Add guard-condition unit tests for `Gate.restart()`

## Details

`Gate.restart()` follows the same structure as `stop()` (wait for the message-loop task, then cleanup) but calls `_exec_restart` instead of exiting. It sets `_RESTARTING = true` like the MCP `:restart` handler does to prevent the message-loop's `finally` block from racing with cleanup. No 0.3s sleep is needed since there's no ZMQ reply to flush.

The TUI restart handler sends `send_restart!` fire-and-forget but intentionally does **not** call `stop_session!` or remove the connection from the manager — `execvp` keeps the same PID and PTY, so the managed session stays valid and the health checker picks up the reconnected gate.

Closes #16

## Test plan

- [ ] From a connected REPL: `Gate.restart()` restarts the session and the TUI reconnects
- [ ] `Gate.restart()` errors when the gate is not running
- [ ] `Gate.restart()` errors when `allow_restart=false`
- [ ] From the TUI Sessions tab: pressing `r` restarts the selected session
- [ ] Agent-spawned sessions reconnect correctly after TUI restart
- [ ] Unit tests pass: `retest("Gate.restart")`
