### PR TITLE
Fix windows compatibility

### DIFF
--- a/src/extension_manager.jl
+++ b/src/extension_manager.jl
@@ -135,7 +135,11 @@ function _build_extension_script(config::ExtensionConfig)
     let sock_dir = Kaimon.Gate.SOCK_DIR
         sub = Kaimon.ZMQ.Socket(Kaimon.Gate._GATE_CONTEXT[], Kaimon.ZMQ.SUB)
         sub.rcvtimeo = 1000  # 1s timeout so loop can check for shutdown
-        Kaimon.ZMQ.connect(sub, "ipc://\$(sock_dir)/kaimon-events.sock")
+        if Sys.iswindows()
+            Kaimon.ZMQ.connect(sub, "tcp://127.0.0.1:\$(Kaimon._EVENT_PUB_TCP_PORT[])")
+        else
+            Kaimon.ZMQ.connect(sub, "ipc://\$(sock_dir)/kaimon-events.sock")
+        end
         $topics_code
         @async begin
             while true

--- a/src/gate.jl
+++ b/src/gate.jl
@@ -1902,7 +1902,7 @@ function serve(;
         elseif toml_mode == "tcp" || has_toml_port
             :tcp
         else
-            :ipc
+            Sys.iswindows() ? :tcp : :ipc
         end
     end
     if host === nothing
@@ -2647,25 +2647,32 @@ end
 # Kaimon calling into the gate, the gate calls back into Kaimon.
 
 const _SERVICE_SOCKET = Ref{Union{ZMQ.Socket,Nothing}}(nothing)
+const _SERVICE_TCP_PORT = Ref{Int}(9877)
 const _SERVICE_LOCK = ReentrantLock()
 
 """
     _connect_service!() -> Bool
 
 Connect to the Kaimon service endpoint. Returns true on success.
-The service socket is a ZMQ REQ that connects to the Kaimon server's
-REP socket at `ipc://~/.cache/kaimon/sock/kaimon-service.sock`.
+IPC on Unix, TCP on Windows (127.0.0.1:$(_SERVICE_TCP_PORT[])).
 """
 function _connect_service!()
-    sock_path = joinpath(SOCK_DIR, "kaimon-service.sock")
-    ispath(sock_path) || return false
     ctx = _GATE_CONTEXT[]
     ctx === nothing && return false
+
+    if Sys.iswindows()
+        endpoint = "tcp://127.0.0.1:$(_SERVICE_TCP_PORT[])"
+    else
+        sock_path = joinpath(SOCK_DIR, "kaimon-service.sock")
+        ispath(sock_path) || return false
+        endpoint = "ipc://$(sock_path)"
+    end
+
     sock = Socket(ctx, REQ)
-    sock.rcvtimeo = 30000  # 30s timeout (some tools are slow)
-    sock.sndtimeo = 5000   # 5s send timeout
+    sock.rcvtimeo = 30000
+    sock.sndtimeo = 5000
     sock.linger = 0
-    connect(sock, "ipc://$(sock_path)")
+    connect(sock, endpoint)
     _SERVICE_SOCKET[] = sock
     return true
 end

--- a/src/gate_client.jl
+++ b/src/gate_client.jl
@@ -250,6 +250,7 @@ mutable struct ConnectionManager
     eval_history::Vector{EvalRecord}       # ring buffer, capped at 64 entries
     eval_history_lock::ReentrantLock
     event_pub_socket::Union{ZMQ.Socket,Nothing}  # global PUB for extension events
+    event_pub_endpoint::String                    # resolved PUB endpoint
     task_queue::Any  # Tachikoma.TaskQueue (or nothing if headless)
 end
 
@@ -266,6 +267,7 @@ function ConnectionManager(; sock_dir::String = joinpath(kaimon_cache_dir(), "so
         nothing,
         EvalRecord[],
         ReentrantLock(),
+        "",
         nothing,
         task_queue,
     )
@@ -305,6 +307,8 @@ end
 # Re-broadcasts gate stream events on a single PUB socket so extensions can
 # SUB to one well-known endpoint with topic filtering.
 
+const _EVENT_PUB_TCP_PORT = Ref{Int}(9878)
+
 """Start the global event PUB socket. Extensions SUB to this."""
 function _start_event_pub!(mgr::ConnectionManager)
     sock_path = joinpath(mgr.sock_dir, "kaimon-events.sock")
@@ -312,8 +316,14 @@ function _start_event_pub!(mgr::ConnectionManager)
     pub = Socket(mgr.zmq_context, PUB)
     pub.sndhwm = 10000  # drop events if extensions can't keep up
     pub.linger = 0
-    bind(pub, "ipc://$sock_path")
+    if Sys.iswindows()
+        endpoint = "tcp://127.0.0.1:$(_EVENT_PUB_TCP_PORT[])"
+    else
+        endpoint = "ipc://$sock_path"
+    end
+    bind(pub, endpoint)
     mgr.event_pub_socket = pub
+    mgr.event_pub_endpoint = endpoint
 end
 
 """Stop the global event PUB socket."""
@@ -322,9 +332,12 @@ function _stop_event_pub!(mgr::ConnectionManager)
     if pub !== nothing
         try; close(pub); catch; end
         mgr.event_pub_socket = nothing
+        mgr.event_pub_endpoint = ""
     end
-    sock_path = joinpath(mgr.sock_dir, "kaimon-events.sock")
-    ispath(sock_path) && try; rm(sock_path); catch; end
+    if !Sys.iswindows()
+        sock_path = joinpath(mgr.sock_dir, "kaimon-events.sock")
+        ispath(sock_path) && try; rm(sock_path); catch; end
+    end
 end
 
 """Re-publish a gate event on the global PUB socket (2-frame: topic + payload)."""

--- a/src/service_endpoint.jl
+++ b/src/service_endpoint.jl
@@ -27,11 +27,14 @@ and calls its handler.
 Returns `(endpoint, socket, context)` on success.
 """
 function start_service_endpoint!()
-    endpoint = "ipc://$(Gate.SOCK_DIR)/kaimon-service.sock"
-    sock_path = replace(endpoint, "ipc://" => "")
-
-    # Clean up stale socket file
-    ispath(sock_path) && rm(sock_path)
+    if Sys.iswindows()
+        endpoint = "tcp://127.0.0.1:$(Gate._SERVICE_TCP_PORT[])"
+    else
+        endpoint = "ipc://$(Gate.SOCK_DIR)/kaimon-service.sock"
+        sock_path = replace(endpoint, "ipc://" => "")
+        # Clean up stale socket file
+        ispath(sock_path) && rm(sock_path)
+    end
 
     ctx = ZMQ.Context()
     sock = Socket(ctx, REP)
@@ -95,11 +98,13 @@ function stop_service_endpoint!()
     end
     _SERVICE_TASK[] = nothing
 
-    # Clean up socket file
-    endpoint = _SERVICE_ENDPOINT[]
-    if !isempty(endpoint)
-        sock_path = replace(endpoint, "ipc://" => "")
-        ispath(sock_path) && rm(sock_path; force = true)
+    # Clean up socket file (IPC only — Windows uses TCP, nothing to clean)
+    if !Sys.iswindows()
+        endpoint = _SERVICE_ENDPOINT[]
+        if !isempty(endpoint)
+            sock_path = replace(endpoint, "ipc://" => "")
+            ispath(sock_path) && rm(sock_path; force = true)
+        end
     end
 
     # Null refs — let GC handle ZMQ cleanup (same pattern as Gate._cleanup)

--- a/src/tui/io.jl
+++ b/src/tui/io.jl
@@ -208,7 +208,12 @@ const _TUI_STDOUT_RUNNING = Ref{Bool}(false)
 function _start_stdout_capture!()
     _TUI_STDOUT_RUNNING[] = true
     _TUI_ORIG_STDOUT[] = stdout
-    _TUI_REAL_STDOUT[] = open("/dev/tty", "w")
+    if Sys.iswindows()
+        _TUI_REAL_STDOUT[] = open("CONOUT\$", "w")
+    else
+        _TUI_REAL_STDOUT[] = open("/dev/tty", "w")
+    end
+
     rd, wr = redirect_stdout()
     _TUI_STDOUT_WR[] = wr
     _TUI_STDOUT_TASK[] = @async begin

--- a/src/tui/lifecycle.jl
+++ b/src/tui/lifecycle.jl
@@ -404,6 +404,15 @@ function _try_revise!()
     return false
 end
 
+function _set_windows_utf8!()
+    Sys.iswindows() || return
+    try
+        ccall((:SetConsoleOutputCP, "kernel32"), Int32, (UInt32,), 65001)
+        ccall((:SetConsoleCP, "kernel32"), Int32, (UInt32,), 65001)
+    catch
+    end
+end
+
 """
     tui(; port=2828, theme=:kokaku)
 
@@ -417,6 +426,7 @@ connections in `~/.cache/kaimon/sock/`.
 - `theme::Symbol=:kokaku`: Tachikoma theme name
 """
 function tui(; port::Int = 2828, theme_name::Union{Symbol,Nothing} = nothing, revise_polling::Bool = false, revise_mod::Any = nothing)
+    _set_windows_utf8!()
     if Threads.nthreads() < 2
         @warn """Kaimon TUI running with only 1 thread — UI may be unresponsive.
                  Start Julia with: julia -t auto


### PR DESCRIPTION
Set UTF-8 code page to prevent TUI garbled text on Windows.
Replace /dev/tty with CONOUT for console output.
Switch ZMQ transport from IPC to TCP, as IPC is not supported on Windows.