### PR TITLE
Fix /dev/tty open on Windows in _start_stdout_capture!

### DIFF
--- a/src/tui/io.jl
+++ b/src/tui/io.jl
@@ -208,7 +208,9 @@ const _TUI_STDOUT_RUNNING = Ref{Bool}(false)
 function _start_stdout_capture!()
     _TUI_STDOUT_RUNNING[] = true
     _TUI_ORIG_STDOUT[] = stdout
-    _TUI_REAL_STDOUT[] = open("/dev/tty", "w")
+    # Open a handle to the controlling terminal that survives `redirect_stdout`.
+    # Unix: /dev/tty. Windows: CON (the console device).
+    _TUI_REAL_STDOUT[] = open(Sys.iswindows() ? "CON" : "/dev/tty", "w")
     rd, wr = redirect_stdout()
     _TUI_STDOUT_WR[] = wr
     _TUI_STDOUT_TASK[] = @async begin


### PR DESCRIPTION
## Summary

On Windows, running `kaimon` crashes at startup with:

```
ERROR: SystemError: opening file "/dev/tty": No such file or directory
 [6] _start_stdout_capture!()
   @ Kaimon .../src/tui/io.jl:211
```

`/dev/tty` is Unix-only. On Windows the equivalent controlling-terminal device is `CON`. This PR uses `Sys.iswindows()` to pick the right path.

## Why this matters

`_TUI_REAL_STDOUT` holds a handle to the real terminal that survives `redirect_stdout()`, and that handle is later assigned to `Tachikoma.Terminal.io` (`src/tui/lifecycle.jl:213`) so the TUI can render even while `stdout` is being captured into the Server log buffer. Without a working terminal handle on Windows, the TUI can't start at all.

## Test plan

- [x] Verified `open("CON", "w")` returns a writable console handle on Windows 11 / Julia 1.12.5.
- [x] After patch, `kaimon` proceeds past `_start_stdout_capture!` and into TUI init (a separate, unrelated `ZMQ: Protocol not supported` error from `ipc://` sockets in `gate_client.jl` is the next Windows blocker — out of scope for this PR; happy to file an issue).
- [x] Patch is a no-op on Unix (still uses `/dev/tty`).

## Note on broader Windows support

This is a one-line compatibility fix and does not claim to make Kaimon fully Windows-ready. The ZMQ IPC transport (`ipc://`) is also unavailable on Windows in the standard `ZMQ_jll` build, which would need a separate fix (e.g. switching to `tcp://127.0.0.1:<port>` or a Windows-named-pipe transport). Filing that as a separate issue.