### PR TITLE
 KaimonGate: supervise the ROUTER message loop; never exit it on a transient ZMQ error

### DIFF
--- a/lib/KaimonGate/src/gate_protocol.jl
+++ b/lib/KaimonGate/src/gate_protocol.jl
@@ -660,16 +660,51 @@ end
 # it calls) runs in the latest world age — required for tools whose types were
 # defined after the gate loop started.
 function _serve_request(identity::Vector{UInt8}, corr_id::Vector{UInt8}, request)
-    reply = try
-        Base.invokelatest(handle_message, request)
-    catch e
-        (type = :error, message = sprint(showerror, e))
+    # Release the slot in a `finally`: a throw after handle_message used to leak
+    # it for the life of the process, and _GATE_MAX_WORKERS leaked slots stop
+    # intake entirely.
+    try
+        reply = try
+            Base.invokelatest(handle_message, request)
+        catch e
+            (type = :error, message = sprint(showerror, e))
+        end
+        io = IOBuffer()
+        try
+            serialize(io, reply)
+        catch e
+            # Still reply, or the client waits out its deadline for nothing.
+            io = IOBuffer()
+            serialize(io, (type = :error,
+                           message = "reply not serializable: $(sprint(showerror, e))"))
+        end
+        put!(_GATE_OUTBOX, (identity, corr_id, take!(io)))
+    finally
+        Threads.atomic_sub!(_GATE_INFLIGHT, 1)
     end
-    io = IOBuffer()
-    serialize(io, reply)
-    put!(_GATE_OUTBOX, (identity, corr_id, take!(io)))
-    Threads.atomic_sub!(_GATE_INFLIGHT, 1)
     return nothing
+end
+
+# ── ZMQ error classification for the owner loop ───────────────────────────────
+# ZMQ.jl raises StateError for every recv errno other than EAGAIN, carrying only
+# the strerror text. EINTR (a signal landed during the recv) is transient and the
+# socket is fine; ETERM and ENOTSOCK mean it will never deliver again. Build the
+# comparison text with the same zmq_strerror ZMQ.jl used, so it matches.
+_zmq_errno_msg(errno::Integer) = unsafe_string(ZMQ.lib.zmq_strerror(Cint(errno)))
+
+"""
+    _zmq_error_disposition(e::ZMQ.StateError) -> :retry | :restart
+
+`:retry` for EINTR (reissue on the same socket); `:restart` for ETERM, ENOTSOCK
+and anything unrecognised (hand the loop to `_supervise_message_loop`, which
+probes the socket, rebinds it if dead and respawns the loop).
+"""
+function _zmq_error_disposition(e::ZMQ.StateError)
+    msg = String(e.msg)
+    if msg == _zmq_errno_msg(Base.Libc.EINTR) || occursin("Interrupted system call", msg)
+        return :retry
+    end
+    return :restart
 end
 
 function message_loop(socket::ZMQ.Socket)
@@ -721,17 +756,27 @@ function message_loop(socket::ZMQ.Socket)
             Threads.atomic_add!(_GATE_INFLIGHT, 1)
             Threads.@spawn _serve_request(identity, corr_id, request)
         catch e
-            if !_RUNNING[]
-                break  # Clean shutdown
-            end
+            _RUNNING[] || break   # clean shutdown
             # Timeout is expected — just loop to check _RUNNING and drain outbox.
-            if e isa ZMQ.TimeoutError
-                continue
+            e isa ZMQ.TimeoutError && continue
+            if e isa ZMQ.StateError
+                if _zmq_error_disposition(e) === :retry
+                    # EINTR: a signal (SIGCHLD from a child, SIGUSR1 from a backtrace
+                    # request) landed during the recv. The socket is fine.
+                    @debug "Kaimon gate message loop: transient ZMQ error, retrying" exception = e
+                    continue
+                end
+                # The socket or context is unusable: rethrow to the supervisor, which
+                # rebinds and respawns. A `break` here left the gate bound and
+                # _RUNNING but deaf for the rest of the process.
+                @warn "Kaimon gate ROUTER socket unusable; leaving message_loop for the supervisor" exception = e
+                rethrow()
             end
-            if e isa ZMQ.StateError || e isa EOFError
-                break
+            if e isa EOFError
+                @warn "Kaimon gate message loop hit EOF; leaving message_loop for the supervisor" exception = e
+                rethrow()
             end
-            @debug "Gate message loop error" exception = e
+            @warn "Kaimon gate message loop error (continuing)" exception = (e, catch_backtrace()) maxlog = 20
         end
     end
 

--- a/lib/KaimonGate/src/gate_serve.jl
+++ b/lib/KaimonGate/src/gate_serve.jl
@@ -363,14 +363,6 @@ function _serve(;
         end
     end
 
-    # Initial receive timeout so the owner loop cycles back to drain _GATE_OUTBOX
-    # (worker replies) and re-check _RUNNING. message_loop then adapts this per
-    # iteration (short while replies are in flight, long when idle) — see
-    # _GATE_RCVTIMEO_BUSY/_IDLE; the flat 200ms here was the input drag-lag.
-    # linger=0: close() returns immediately without blocking to drain.
-    socket.rcvtimeo = _GATE_RCVTIMEO_IDLE[]
-    socket.linger = 0
-
     # CURVE (opt-in, TCP only): make the REP socket a CURVE server. Unless
     # allow_any, also start a ZAP handler (one per context, covers PUB too) and
     # set ZAP_DOMAIN so libzmq enforces the client allow-list (fail-closed: an
@@ -385,9 +377,9 @@ function _serve(;
             isempty(ck) || authorize_client!(ck)
         end
         allow_any || _start_zap_handler!(ctx; allow_any = false)
-        make_curve_server!(socket, ssec)
-        allow_any || _setsockopt_str(socket, _ZMQ_ZAP_DOMAIN, _ZAP_DOMAIN)
     end
+    # Shared with _ensure_router!, so a supervisor rebind replays exactly this.
+    _configure_router_socket!(socket; curve = mode == :tcp && curve, allow_any)
 
     # Bind endpoint — IPC (local socket file) or TCP (network port)
     # TCP mode supports port=0 for ephemeral port assignment (ZMQ picks a free port).
@@ -476,15 +468,21 @@ function _serve(;
         try
             _stream_broadcaster(pub_socket)
         catch e
-            @debug "Stream broadcaster exited" exception = e
+            if _RUNNING[]
+                @warn "Kaimon gate stream broadcaster exited while the gate is running" exception = (e, catch_backtrace())
+            else
+                @debug "Stream broadcaster exited" exception = e
+            end
         end
     end
     local this_task
     this_task = _GATE_TASK[] = Threads.@spawn :interactive begin
         try
-            message_loop(socket)
+            _supervise_message_loop(socket)
         catch e
-            @debug "Gate task exited" exception = e
+            # message_loop faults are handled inside the supervisor; this is the
+            # supervisor itself failing.
+            @error "Kaimon gate supervisor task exited" exception = (e, catch_backtrace())
         finally
             if _SHUTTING_DOWN[]
                 # Remote shutdown: run optional cleanup hook, then exit
@@ -601,6 +599,120 @@ function _serve(;
     end
 
     return sid
+end
+
+# ── Control-plane supervision ─────────────────────────────────────────────────
+# The ROUTER owner loop is the gate's whole control plane. If it exits while the
+# gate is running, Kaimon gets no pong and every tool call fails with "Gate not
+# connected" while the process, the bound socket and _RUNNING all look healthy.
+# It used to be spawned once with its exit swallowed at @debug, so one EINTR
+# silenced a gate for the rest of the process.
+
+_gate_should_run() = _RUNNING[] && !_SHUTTING_DOWN[] && !_RESTARTING[]
+
+# sleep(s) that returns early when the gate is asked to stop, so a backoff never
+# holds up stop()/restart(), which wait on the gate task.
+function _sleep_while_running(s::Real)
+    deadline = time() + s
+    while _gate_should_run() && time() < deadline
+        sleep(clamp(deadline - time(), 0.001, 0.05))
+    end
+    return nothing
+end
+
+"""
+    _supervise_message_loop(socket)
+
+Run `message_loop` for as long as the gate should be running. It returns normally
+only once `_RUNNING` is false; any other exit is logged and the loop is respawned
+after a backoff, on a rebound ROUTER if the old one is dead (`_ensure_router!`).
+`stop()`, `restart()`, `:shutdown` and `:restart` clear the lifecycle flags
+first, so they exit here quietly.
+"""
+function _supervise_message_loop(socket::ZMQ.Socket)
+    backoff = 0.1
+    while _gate_should_run()
+        t0 = time()
+        err = nothing
+        try
+            message_loop(socket)
+        catch e
+            err = (e, catch_backtrace())
+        end
+        if !_gate_should_run()
+            err === nothing || @debug "Kaimon gate message loop error during shutdown" exception = err
+            break
+        end
+        # A healthy stretch before the fault resets the backoff.
+        time() - t0 > 60.0 && (backoff = 0.1)
+        uptime_s = round(time() - t0; digits = 1)
+        if err === nothing
+            @warn "Kaimon gate message loop returned while the gate is running; respawning" uptime_s backoff_s = backoff
+        else
+            @error "Kaimon gate message loop died; respawning" exception = err uptime_s backoff_s = backoff
+        end
+        _sleep_while_running(backoff)
+        backoff = min(backoff * 2, 5.0)
+        _gate_should_run() || break
+        socket = try
+            _ensure_router!(socket)
+        catch e
+            # Context gone or bind failed: keep the old handle, probe again next pass.
+            @error "Kaimon gate could not rebind its ROUTER socket; will retry" exception = (e, catch_backtrace())
+            socket
+        end
+    end
+    return nothing
+end
+
+"""
+    _configure_router_socket!(socket; curve, allow_any)
+
+Per-socket options for the request ROUTER, applied by `serve` and replayed by
+`_ensure_router!` on a rebind. The receive timeout makes the owner loop cycle
+back to drain `_GATE_OUTBOX` and re-check `_RUNNING` (`message_loop` then adapts
+it per iteration, see `_GATE_RCVTIMEO_BUSY`/`_IDLE`); `linger = 0` so `close()`
+does not block; the CURVE server role reuses the context-wide keypair and ZAP
+handler `serve` set up.
+"""
+function _configure_router_socket!(socket::ZMQ.Socket; curve::Bool, allow_any::Bool)
+    socket.rcvtimeo = _GATE_RCVTIMEO_IDLE[]
+    socket.linger = 0
+    if curve
+        make_curve_server!(socket, _CURVE_SERVER_SECRET[])
+        allow_any || _setsockopt_str(socket, _ZMQ_ZAP_DOMAIN, _ZAP_DOMAIN)
+    end
+    return socket
+end
+
+"""
+    _ensure_router!(sock) -> ZMQ.Socket
+
+Return a usable ROUTER on the gate's endpoint: `sock` itself if it is open and
+answers a `getsockopt`, otherwise a fresh socket configured and bound in its place
+(the IPC path is unlinked first, as `serve(force=true)` does). The client's DEALER
+reconnects on its own. Throws if the context is gone or the bind fails; the
+supervisor logs that and retries.
+"""
+function _ensure_router!(sock::ZMQ.Socket)
+    alive = isopen(sock) && (try; sock.events; true; catch; false; end)
+    alive && return sock
+    try; close(sock); catch; end
+    ctx = _GATE_CONTEXT[]
+    ctx === nothing && error("gate ZMQ context is gone; cannot rebind the ROUTER")
+    new = _zmq_socket(ctx, ROUTER)
+    _configure_router_socket!(new; curve = _CURVE_ENABLED[], allow_any = _CURVE_ALLOW_ANY[])
+    endpoint = if _MODE[] == :tcp
+        "tcp://$(_TCP_HOST[]):$(_TCP_PORT[])"
+    else
+        sock_path = joinpath(sock_dir(), "$(_SESSION_ID[]).sock")
+        rm(sock_path; force = true)
+        "ipc://$(sock_path)"
+    end
+    bind(new, endpoint)
+    _GATE_SOCKET[] = new
+    @warn "Kaimon gate ROUTER socket was dead; rebound" endpoint
+    return new
 end
 
 """

--- a/lib/KaimonGate/test/runtests.jl
+++ b/lib/KaimonGate/test/runtests.jl
@@ -8,6 +8,7 @@ using SafeTestsets
 @safetestset "Tool dispatch" include("src/test_dispatch.jl")
 @safetestset "Source docstring" include("src/test_source_docstring.jl")
 @safetestset "Message handler" include("src/test_handle_message.jl")
+@safetestset "Loop supervision" include("src/test_loop_supervision.jl")
 @safetestset "Capture race" include("src/test_capture_race.jl")
 @safetestset "Stream guard" include("src/test_stream_guard.jl")
 @safetestset "Concurrent eval" include("src/test_eval_concurrency.jl")

--- a/lib/KaimonGate/test/src/test_loop_supervision.jl
+++ b/lib/KaimonGate/test/src/test_loop_supervision.jl
@@ -1,0 +1,141 @@
+# Control-plane supervision, the parts checkable without a live Kaimon: ZMQ error
+# classification, worker-slot accounting, the supervisor's lifecycle gate, and
+# _ensure_router! against a real socket. test_integration.jl covers the loop itself.
+
+using Test
+using KaimonGate
+using Serialization
+
+const KG = KaimonGate
+const ZMQ = KG.ZMQ
+
+# ── ZMQ.StateError classification ─────────────────────────────────────────────
+# Messages are built the way ZMQ.jl builds them (libzmq's zmq_strerror).
+
+@testset "ZMQ error disposition" begin
+    eintr = ZMQ.StateError(KG._zmq_errno_msg(Base.Libc.EINTR))
+    @test KG._zmq_error_disposition(eintr) === :retry
+    @test KG._zmq_error_disposition(ZMQ.StateError("Interrupted system call")) === :retry
+
+    eterm = ZMQ.StateError(KG._zmq_errno_msg(ZMQ.lib.ETERM))
+    @test KG._zmq_error_disposition(eterm) === :restart
+    enotsock = ZMQ.StateError(KG._zmq_errno_msg(Base.Libc.ENOTSOCK))
+    @test KG._zmq_error_disposition(enotsock) === :restart
+    # Unrecognised text goes to the supervisor too.
+    @test KG._zmq_error_disposition(ZMQ.StateError("some new libzmq condition")) === :restart
+end
+
+# ── Worker-slot accounting ────────────────────────────────────────────────────
+
+function _drain_outbox!()
+    while isready(KG._GATE_OUTBOX)
+        take!(KG._GATE_OUTBOX)
+    end
+end
+
+@testset "_serve_request releases its slot and always replies" begin
+    _drain_outbox!()
+    base = KG._GATE_INFLIGHT[]
+    id, cid = UInt8[1, 2], UInt8[3, 4]
+
+    # Normal path: a ping is handled, replied to, and the slot comes back.
+    Threads.atomic_add!(KG._GATE_INFLIGHT, 1)
+    KG._serve_request(id, cid, (type = :ping,))
+    @test KG._GATE_INFLIGHT[] == base
+    (rid, rcid, bytes) = take!(KG._GATE_OUTBOX)
+    @test rid == id && rcid == cid
+    @test deserialize(IOBuffer(bytes)).type === :pong
+
+    # handle_message cannot dispatch a non-NamedTuple: error reply, slot released.
+    Threads.atomic_add!(KG._GATE_INFLIGHT, 1)
+    KG._serve_request(id, cid, Dict(:type => :ping))
+    @test KG._GATE_INFLIGHT[] == base
+    reply = deserialize(IOBuffer(take!(KG._GATE_OUTBOX)[3]))
+    @test reply.type === :error
+
+    # An unknown request type is still a reply, not a leaked slot.
+    Threads.atomic_add!(KG._GATE_INFLIGHT, 1)
+    KG._serve_request(id, cid, (type = :no_such_message,))
+    @test KG._GATE_INFLIGHT[] == base
+    @test isready(KG._GATE_OUTBOX)
+    _drain_outbox!()
+end
+
+# ── Supervisor lifecycle gate ─────────────────────────────────────────────────
+# stop, restart, :shutdown and :restart each clear _RUNNING and may raise
+# _SHUTTING_DOWN or _RESTARTING first; the supervisor must stand down on any of them.
+
+@testset "_gate_should_run honours every lifecycle flag" begin
+    saved = (KG._RUNNING[], KG._SHUTTING_DOWN[], KG._RESTARTING[])
+    try
+        KG._RUNNING[] = true; KG._SHUTTING_DOWN[] = false; KG._RESTARTING[] = false
+        @test KG._gate_should_run()
+        KG._SHUTTING_DOWN[] = true
+        @test !KG._gate_should_run()
+        KG._SHUTTING_DOWN[] = false; KG._RESTARTING[] = true
+        @test !KG._gate_should_run()
+        KG._RESTARTING[] = false; KG._RUNNING[] = false
+        @test !KG._gate_should_run()
+        # The fault-path backoff returns as soon as the gate is asked to stop.
+        KG._RUNNING[] = true
+        t = @elapsed begin
+            @async (sleep(0.1); KG._RUNNING[] = false)
+            KG._sleep_while_running(5.0)
+        end
+        @test t < 2.0
+    finally
+        KG._RUNNING[], KG._SHUTTING_DOWN[], KG._RESTARTING[] = saved
+    end
+end
+
+# ── Rebind helper against a real socket (no Kaimon involved) ──────────────────
+
+@testset "_ensure_router! keeps a live socket and rebinds a dead one" begin
+    if KG._RUNNING[] || Sys.iswindows()
+        @test_skip true
+    else
+        saved = (KG._GATE_CONTEXT[], KG._GATE_SOCKET[], KG._MODE[], KG._SESSION_ID[])
+        ctx = ZMQ.Context()
+        sid = "test-rebind-$(bytes2hex(rand(UInt8, 4)))"
+        path = joinpath(KG.sock_dir(), "$sid.sock")
+        try
+            KG._GATE_CONTEXT[] = ctx
+            KG._MODE[] = :ipc
+            KG._SESSION_ID[] = sid
+            s = KG._zmq_socket(ctx, ZMQ.ROUTER)
+            KG._configure_router_socket!(s; curve = false, allow_any = false)
+            ZMQ.bind(s, "ipc://$path")
+            KG._GATE_SOCKET[] = s
+
+            # Live socket: returned untouched.
+            @test KG._ensure_router!(s) === s
+            @test KG._GATE_SOCKET[] === s
+
+            # Dead socket (the ENOTSOCK case): rebound on the same endpoint with
+            # the same options.
+            close(s)
+            s2 = @test_logs (:warn, r"rebound") KG._ensure_router!(s)
+            @test s2 !== s
+            @test isopen(s2)
+            @test KG._GATE_SOCKET[] === s2
+            @test ispath(path)
+            @test s2.rcvtimeo == KG._GATE_RCVTIMEO_IDLE[]
+            @test s2.linger == 0
+
+            # A client reaches the rebound endpoint.
+            d = ZMQ.Socket(ctx, ZMQ.DEALER)
+            d.linger = 0
+            ZMQ.connect(d, "ipc://$path")
+            ZMQ.send(d, "hello")
+            s2.rcvtimeo = 2000
+            parts = KG._recv_multipart(s2)
+            @test String(parts[end]) == "hello"
+            close(d)
+            close(s2)
+        finally
+            KG._GATE_CONTEXT[], KG._GATE_SOCKET[], KG._MODE[], KG._SESSION_ID[] = saved
+            try; close(ctx); catch; end
+            rm(path; force = true)
+        end
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/kahliburke/Kaimon.jl/issues/86

Four files, all under `lib/KaimonGate/`: `src/gate_protocol.jl`, `src/gate_serve.jl`, `test/runtests.jl`, and a new `test/src/test_loop_supervision.jl`. No wire-protocol change, no `Project.toml` change, no client change.

## What the fix does

Three changes, each closing one gap in the failure chain: the loop no longer exits on a transient error (P2), an exit that does happen is noticed and recovered instead of leaving a bound socket nobody reads (P1), and a throwing worker can no longer leak the loop into a permanent at-cap state (P3).

### P2: classify ZMQ recv errors instead of breaking (`gate_protocol.jl`)

This is the direct fix. The `catch` block at the end of `message_loop` used to `break` on any `ZMQ.StateError` or `EOFError`. It now does the following:

- `ZMQ.TimeoutError`: `continue`, exactly as before.
- `ZMQ.StateError` from EINTR: log at `@debug` and `continue` on the same socket. The recv is simply reissued; the socket is unaffected by EINTR.
- `ZMQ.StateError` from anything else (ETERM, ENOTSOCK, or text we do not recognise) and `EOFError`: log at `@warn` and `rethrow` to the supervisor, which decides whether the socket needs rebinding.
- Any other exception: log at `@warn` (with `maxlog = 20`) and continue, where it used to log at `@debug`.

The only `break` left is the one guarded by `!_RUNNING[]`, the clean shutdown.

ZMQ.jl's `StateError` carries only the `zmq_strerror` text, not the errno, so `_zmq_error_disposition` compares that text against `zmq_strerror(EINTR)` obtained from the same libzmq call ZMQ.jl used, plus the literal "Interrupted system call" as a fallback. EINTR is `:retry`; everything else is `:restart`. Unknown text deliberately goes to the supervisor rather than being retried: a retry loop on a socket that will never deliver would be a busy loop.

### P1: supervise the loop (`gate_serve.jl`)

The gate task now runs `_supervise_message_loop(socket)` instead of calling `message_loop(socket)` directly.

While `_gate_should_run()` holds (`_RUNNING` true, neither `_SHUTTING_DOWN` nor `_RESTARTING` set), any exit of `message_loop` is logged and the loop is run again. A throw is logged at `@error` with the backtrace; a plain return while the gate is still meant to be running is logged at `@warn`. The respawn waits a backoff starting at 0.1 s and doubling to a 5 s cap; a loop that ran for more than 60 s before failing resets the backoff, so an isolated fault after hours of uptime costs 0.1 s, and only a fault that repeats immediately backs off.

Before respawning, `_ensure_router!` probes the socket with a `getsockopt`. If it answers, the same socket is reused; nothing is closed or rebound. If it does not (ENOTSOCK, or the context was destroyed under it), the dead socket is closed and a fresh ROUTER is configured and bound on the same endpoint, unlinking the IPC path first as `serve(force = true)` already does. The client's DEALER reconnects on its own, so Kaimon needs no change. If the context is gone or the bind fails, that is logged at `@error` and retried on the next pass.

`_configure_router_socket!` is the rcvtimeo, linger and CURVE-server setup moved out of `_serve` into a helper that `_ensure_router!` also calls, so a rebound socket has exactly the options `serve` gave the original. It is moved code; `_serve` applies the same options in the same order as before.

Clean exits are unchanged. `stop()`, `restart()`, `:shutdown` and `:restart` all clear `_RUNNING` (and raise their own flag) before the loop exits, so the supervisor sees `_gate_should_run() == false` and returns without respawning. `_sleep_while_running` makes the backoff return as soon as a stop is requested, so `stop()` and `restart()`, which `wait` on the gate task, are not held up by a backoff in progress.

Two log-level changes ride along: the gate task's own exit is now `@error` (it was `@debug`; with the supervisor in place, that task exiting means the supervisor itself failed), and the stream broadcaster's exit is `@warn` while the gate is running (it was `@debug`). The broadcaster is not supervised; that is a separate socket and would be a separate change.

### P3: a worker slot cannot leak (`gate_protocol.jl`)

`_serve_request` released its `_GATE_INFLIGHT` slot as the last statement, after `serialize` and `put!`. A throw in that tail leaked the slot for the life of the process, and `_GATE_MAX_WORKERS` leaked slots put the owner loop at its cap permanently, where it stops reading. The decrement is now in a `finally`. A reply that fails to serialize still produces an `:error` reply naming the serialization failure, so the client gets an answer instead of waiting out its deadline. The increment stays where it was, inline in `message_loop` just before the `@spawn`.

## Tests

`test/src/test_loop_supervision.jl`, registered in `runtests.jl`:

- `_zmq_error_disposition`: EINTR (both as `zmq_strerror(EINTR)` and as the literal text) is `:retry`; ETERM, ENOTSOCK and unrecognised text are `:restart`.
- `_serve_request` releases its slot and always replies: on a normal `:ping`, on a request `handle_message` cannot dispatch, and on an unknown message type.
- `_gate_should_run` honours all three lifecycle flags, and `_sleep_while_running` returns early when the gate is asked to stop.
- `_ensure_router!` against a real IPC ROUTER, no Kaimon involved: a live socket is returned untouched; a closed one is rebound on the same endpoint with the same rcvtimeo and linger, and a DEALER can reach it.

The full KaimonGate suite passes (`Pkg.test("KaimonGate")`, Julia 1.12, Linux, `-t 4`). `test_integration.jl` continues to exercise the loop itself end to end.
